### PR TITLE
feat: accept float numbers for royalty and fees

### DIFF
--- a/minting-tool/typescript/src/cli.ts
+++ b/minting-tool/typescript/src/cli.ts
@@ -247,7 +247,7 @@ async function initProject(name: string, assetPath: string) {
     recursive: true,
   });
 
-  let enableWL = false;
+  const enableWL = true;
 
   const questions = [
     {
@@ -306,17 +306,6 @@ async function initProject(name: string, assetPath: string) {
       float: true,
       name: "mintPrice",
       message: "Enter the public minting price in APTs",
-    },
-    {
-      type: "confirm",
-      name: "enableWL",
-      message: "Do you want to support whitelist minting?",
-    },
-    {
-      type: (prev: any) => {
-        enableWL = prev;
-        return null;
-      },
     },
     {
       type: () => (enableWL ? "date" : null),


### PR DESCRIPTION
1. accept float numbers for royalty and minting fees
2. added one more check to make sure token attributes are unique
3. get rid of "do you want to enable white list...". White list settings must be provided today.